### PR TITLE
1.19.2 Port (and some fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 /forge/.idea/
 /forge/package.json
 /forge/package-lock.json
+/forge/run
+/forge/build
+/forge/.gradle
 /fabric/.idea/
 /fabric/package.json
 /fabric/package-lock.json
+/fabric/run
+/fabric/build
+/fabric/.gradle
+.idea

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -41,14 +41,10 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	modLocalRuntime("maven.modrinth:lazydfu:0.1.2") // lazydfu - improves start times
-	modLocalRuntime("maven.modrinth:suggestion-tweaker:${project.suggestion_tweaker_version}") // suggestion tweaker - dev QOL, improves command suggestions
-	modLocalRuntime("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") { exclude(group: "net.fabricmc.fabric-api") } // required for suggestion tweaker and REI
+	modLocalRuntime("maven.modrinth:lazydfu:${project.lazydfu_version}") // lazydfu - improves start times
 	modLocalRuntime("com.terraformersmc:modmenu:${project.modmenu_version}") { exclude group: "net.fabricmc"; exclude group: "net.fabricmc.fabric-api" } // always good to have
 
 	// recipe viewers
-	modRuntimeOnly("dev.architectury:architectury-fabric:${project.architectury_version}") // for REI
-	modRuntimeOnly("me.shedaniel.cloth:basic-math:0.6.0") // for REI
 	modCompileOnly("me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}") { transitive = false }
 	modCompileOnly("me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}") { transitive = false }
 	modCompileOnly("dev.emi:emi:${project.emi_version}") { transitive = false }
@@ -57,7 +53,10 @@ dependencies {
 	if (recipeViewer == "emi") {
 		modLocalRuntime("dev.emi:emi:${project.emi_version}")  { transitive = false }
 	} else if (recipeViewer == "rei") {
+		modRuntimeOnly("dev.architectury:architectury-fabric:${project.architectury_version}") { transitive = false }
+		modRuntimeOnly("me.shedaniel.cloth:basic-math:0.6.0") { transitive = false }
 		modLocalRuntime("me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}") { transitive = false }
+		modLocalRuntime("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") { exclude(group: "net.fabricmc.fabric-api"); transitive = false }
 	} else {
 		println("unknown recipe viewer: $recipeViewer")
 	}
@@ -67,14 +66,13 @@ dependencies {
 	modImplementation("com.github.AlphaMode:fakeconfigtoml:master-SNAPSHOT") { exclude(group: "net.fabricmc.fabric-api") }
 
 	// create setup
-	modImplementation("com.simibubi:Create:${project.create_version}") { transitive = false }
-	modImplementation("io.github.fabricators_of_create:Porting-Lib:${project.port_lib_version}+${project.minecraft_version}-dev.${project.port_lib_hash}")
-	modImplementation("me.alphamode:ForgeTags:${project.forge_tags_version}")
+	modImplementation("com.simibubi.create:create-fabric-${project.minecraft_version}:${project.create_version}") { transitive = false }
+	modImplementation("io.github.fabricators_of_create.Porting-Lib:porting-lib:${project.port_lib_version}+${project.minecraft_version}")
 	modImplementation(include("com.electronwill.night-config:core:${project.night_config_core_version}"))
 	modImplementation(include("com.electronwill.night-config:toml:${project.night_config_toml_version}"))
 	modImplementation("curse.maven:forge-config-api-port-fabric-547434:${project.config_api_id}") { transitive = false }
-	modImplementation("com.tterrag.registrate:Registrate:${project.registrate_version}")
-	modImplementation("com.jozufozu.flywheel:flywheel-fabric-1.18.2:${project.flywheel_version}")
+	modImplementation("com.tterrag.registrate_fabric:Registrate:${project.registrate_version}-MC${project.minecraft_version}")
+	modImplementation("com.jozufozu.flywheel:flywheel-fabric-${project.minecraft_version}:${project.flywheel_version}")
 	modImplementation("com.jamieswhiteshirt:reach-entity-attributes:${project.reach_entity_attributes_version}")
 	modImplementation("dev.cafeteria:fake-player-api:${project.fake_player_api_version}")
 	modImplementation("io.github.tropheusj:milk-lib:${project.milk_lib_version}")
@@ -82,32 +80,12 @@ dependencies {
 
 	// CC:R setup
 	modImplementation("com.github.cc-tweaked:cc-restitched:${project.cc_version}")
+	modApi("com.github.cc-tweaked:cc-restitched:${project.cc_version}")
 
 	// dependencies
 	modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}")
 
 
-
-
-
-
-
-
-
-
-	// To change the versions see the gradle.properties file
-	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-
-
-
-	modApi "com.github.cc-tweaked:cc-restitched:${project.cc_version}"
-
-	// create setup
-	modImplementation("com.simibubi:Create:${project.create_version}") { transitive = false }
-
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 }
 
 processResources {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -31,7 +31,7 @@ repositories {
 	maven { url = "https://mvn.devos.one/snapshots/" } // Create, Porting Lib, Forge Tags, Milk Lib
 	maven { url = "https://cursemaven.com" } // Forge Config API Port
 	maven { url = "https://maven.tterrag.com/" } // Registrate and Flywheel
-	maven { url = "https://maven.cafeteria.dev" } // Fake Player API
+	maven { url = "https://maven.cafeteria.dev/releases" } // Fake Player API
 	maven { url = "https://maven.jamieswhiteshirt.com/libs-release" } // Reach Entity Attributes
 	maven { url = "https://jitpack.io/" } // Mixin Extras, fabric ASM
 }

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.3
-loader_version=0.14.8
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.28
+loader_version=0.14.10
 
 # Mod Properties
 mod_version = 1.3.1
@@ -13,43 +13,41 @@ maven_group = cc.tweaked_programs
 archives_base_name = cccbridge
 
 # Dependencies
-fabric_version=0.57.0+1.18.2
-cc_version=v1.18.2-1.100.5-ccr
+fabric_version=0.67.1+1.19.2
+cc_version=v1.19.1-1.101.2-ccr
 
 # Create setup
 # https://modrinth.com/mod/create-fabric
-create_version = 0.5.0c-691
+create_version = 0.5.0f-776
 
-# https://github.com/Fabricators-of-Create/Create/blob/mc1.18/fabric/dev/gradle.properties
-config_api_id = 3671141
-forge_config_api_port_version = 3.2.0
-fake_player_api_version = 0.3.0
-flywheel_version = 0.6.4-30
-reach_entity_attributes_version = 2.1.1
-registrate_version = MC1.18.2-1.1.3
-forge_tags_version = 2.1
-milk_lib_version = 0.3.2
-port_lib_version = 1.2.421-beta
-port_lib_hash = b8d195a
+# https://github.com/Fabricators-of-Create/Create/blob/mc1.19/fabric/dev/gradle.properties
+config_api_id = 3960064
+forge_config_api_port_version = 4.2.6
+fake_player_api_version = 0.5.0
+flywheel_version = 0.6.8-1
+reach_entity_attributes_version = 2.3.0
+registrate_version = 1.1.44
+milk_lib_version = 1.0.51
+port_lib_version = 2.0.617
 night_config_core_version = 3.6.3
 night_config_toml_version = 3.6.3
 jsr305_version = 3.0.2
 
 # dev env mods
 # https://modrinth.com/mod/modmenu
-modmenu_version = 3.2.2
-# https://modrinth.com/mod/suggestion-tweaker
-suggestion_tweaker_version = 1.18.x-1.2.0
+modmenu_version = 4.1.0
+# https://modrinth.com/mod/lazydfu
+lazydfu_version = 0.1.3
 # https://modrinth.com/mod/cloth-config
-cloth_config_version = 6.2.62
+cloth_config_version = 8.2.88
 
 # dev env recipe viewers
 # https://www.curseforge.com/minecraft/mc-mods/architectury-fabric
-architectury_version = 4.1.39
+architectury_version = 6.3.49
 # https://www.curseforge.com/minecraft/mc-mods/roughly-enough-items/files
-rei_version = 8.0.442
+rei_version = 9.1.565
 # https://github.com/emilyploszaj/emi/releases/
-emi_version = 0.2.0+1.18.2
+emi_version = 0.4.2+1.19
 
 # What recipe viewer to use in dev (emi or rei)
 recipe_viewer = rei

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/blockEntity/ScrollerBlockEntity.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/blockEntity/ScrollerBlockEntity.java
@@ -8,6 +8,7 @@ import com.simibubi.create.foundation.tileEntity.SmartTileEntity;
 import com.simibubi.create.foundation.tileEntity.TileEntityBehaviour;
 import com.simibubi.create.foundation.tileEntity.behaviour.ValueBoxTransform;
 import com.simibubi.create.foundation.tileEntity.behaviour.scrollvalue.ScrollValueBehaviour;
+import com.simibubi.create.foundation.utility.Lang;
 import com.simibubi.create.foundation.utility.VecHelper;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.peripheral.IPeripheralTile;
@@ -15,7 +16,6 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.state.property.Properties;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
@@ -90,7 +90,7 @@ public class ScrollerBlockEntity extends SmartTileEntity implements IPeripheralT
         ScrollValueBehaviour scroller = new ScrollValueBehaviour(getCachedState().getBlock().getName(), this, new ControllerValueBoxTransform())
                 .between(-150, 150)
                 .moveText(new Vec3d(9, 0, 10))
-                .withUnit(i -> new TranslatableText("cccbridge.general.unit.scroller"))
+                .withUnit(i -> Lang.translateDirect("cccbridge.general.unit.scroller"))
                 .withCallback(i -> { if (this.peripheral != null) peripheral.newValue(i); })
                 .interactiveWhen(playerEntity -> !(playerEntity.getWorld().getBlockState(this.getPos()).get(Properties.LOCKED)))
                 .withStepFunction(context -> context.shift ? 1 : 10)

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/display/SourceBlockDisplaySource.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/display/SourceBlockDisplaySource.java
@@ -4,9 +4,9 @@ import cc.tweaked_programs.cccbridge.blockEntity.SourceBlockEntity;
 import com.simibubi.create.content.logistics.block.display.DisplayLinkContext;
 import com.simibubi.create.content.logistics.block.display.source.DisplaySource;
 import com.simibubi.create.content.logistics.block.display.target.DisplayTargetStats;
+import com.simibubi.create.foundation.utility.Lang;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.text.MutableText;
-import net.minecraft.text.TranslatableText;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -25,7 +25,7 @@ public class SourceBlockDisplaySource extends DisplaySource {
 
         List<MutableText> content = new LinkedList<>();
         for (String line : data)
-            content.add(new TranslatableText("").append(line));
+            content.add(Lang.translateDirect("").append(line));
 
         return content;
     }

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/peripherals/TrainPeripheral.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/peripherals/TrainPeripheral.java
@@ -101,11 +101,15 @@ public class TrainPeripheral implements IPeripheral {
     /**
      * Returns the current trains name.
      *
-     * @return Name of train.
+     * @return Whether it was successful or not with the train's name.
      */
     @LuaFunction
-    public String getTrainName() {
-        return Objects.requireNonNull(station.getStation().getPresentTrain()).name.getString();
+    public MethodResult getTrainName() {
+        if (station.getStation().getPresentTrain() == null) {
+            return MethodResult.of(false, "There is no assembled train to get the name of");
+        }else {
+            return MethodResult.of(true, Objects.requireNonNull(station.getStation().getPresentTrain()).name.getString());
+        }
     }
 
     /**
@@ -156,12 +160,12 @@ public class TrainPeripheral implements IPeripheral {
     }
 
     /**
-     * Gets the number of Bogeys attached to the current train.
+     * Gets the number of Carriages attached to the current train.
      *
-     * @return The number of Bogeys.
+     * @return The number of Carriages.
      */
     @LuaFunction
-    public int getBogeys() {
+    public int getCarriageCount() {
         if (station.getStation().getPresentTrain() == null) {
             return 0;
         }

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/peripherals/TrainPeripheral.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/peripherals/TrainPeripheral.java
@@ -81,7 +81,7 @@ public class TrainPeripheral implements IPeripheral {
             Direction direction = station.getAssemblyDirection();
             BlockPos position = station.edgePoint.getGlobalPosition().up();
             this.schedule = station.getStation().getPresentTrain().runtime.getSchedule();
-            ServerPlayerEntity player = new ServerPlayerEntity(level.getServer(), level.getServer().getOverworld(), new GameProfile(UUID.fromString("069a79f4-44e9-4726-a5be-fca90e38aaf5"), "Notch"));
+            ServerPlayerEntity player = new ServerPlayerEntity(level.getServer(), level.getServer().getOverworld(), new GameProfile(UUID.fromString("069a79f4-44e9-4726-a5be-fca90e38aaf5"), "Notch"), null);
             station.getStation().getPresentTrain().disassemble(player, direction, position);
             return MethodResult.of(true, "Train disassembled");
         }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -31,14 +31,11 @@
   ],
 
   "depends": {
-    "create": "*",
-    "computercraft": ">=1.100.5",
-    "fabricloader": ">=0.14.6",
-    "fabric": "*",
-    "minecraft": "~1.18.2",
+    "create": ">=0.5.0f-776",
+    "computercraft": ">=1.101.2",
+    "fabricloader": ">=0.14.10",
+    "fabric": "0.67.1",
+    "minecraft": "~1.19.2",
     "java": ">=17"
-  },
-  "suggests": {
-    "another-mod": "*"
   }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -24,7 +24,7 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
 minecraft {
-    mappings channel: 'official', version: '1.18.2'
+    mappings channel: 'official', version: "${mc_version}"
 
     runs {
         client {
@@ -116,11 +116,12 @@ dependencies {
     minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 
-    runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}") // Adds the full JEI mod as a runtime dependency
+    runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}") // Adds the full JEI mod as a runtime dependency
 
     implementation fg.deobf("org.squiddev:cc-tweaked-${mc_version}:${cc_version}")
-    implementation fg.deobf("com.simibubi.create:Create:mc${mc_version}_${create_version}")
-    implementation fg.deobf("com.jozufozu.flywheel:Flywheel-Forge:${flywheel_version}")
+    implementation fg.deobf("com.simibubi.create:create-${mc_version}:${create_version}:slim") {transitive = false}
+    implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-${mc_version}:${flywheel_version}")
+    implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
 }
 
 jar {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -24,7 +24,7 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
 minecraft {
-    mappings channel: 'official', version: '1.18.2'
+    mappings channel: 'official', version: "${mc_version}"
 
     runs {
         client {
@@ -119,8 +119,9 @@ dependencies {
     runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}") // Adds the full JEI mod as a runtime dependency
 
     implementation fg.deobf("org.squiddev:cc-tweaked-${mc_version}:${cc_version}")
-    implementation fg.deobf("com.simibubi.create:Create:mc${mc_version}_${create_version}")
-    implementation fg.deobf("com.jozufozu.flywheel:Flywheel-Forge:${flywheel_version}")
+    implementation fg.deobf("com.simibubi.create:create-${mc_version}:${create_version}:slim") { transitive = false }
+    implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-${mc_version}:${flywheel_version}")
+    implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
 }
 
 jar {

--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -4,14 +4,15 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Properties
-mc_version=1.18.2
-forge_version=40.1.0
+mc_version=1.19.2
+forge_version=43.1.1
 mod_version=1.3.1
 
 # Mod dependencies
-cc_version=1.101.0
-create_version=v0.5.0c+146
-flywheel_version=1.18-0.6.4.87
+cc_version=1.101.1
+create_version=0.5.0.f-15
+flywheel_version=0.6.7-8
+registrate_version = MC1.19-1.1.5
 
 # Runtime only
-jei_version=9.7.0.209
+jei_version=11.4.0.286

--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -5,13 +5,14 @@ org.gradle.daemon=false
 
 # Properties
 mc_version=1.18.2
-forge_version=40.1.0
+forge_version=40.1.60
 mod_version=1.3.1
 
 # Mod dependencies
 cc_version=1.101.0
-create_version=v0.5.0c+146
-flywheel_version=1.18-0.6.4.87
+create_version = 0.5.0.e-195
+flywheel_version = 0.6.6-94
+registrate_version = MC1.18.2-1.1.3
 
 # Runtime only
 jei_version=9.7.0.209

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/BlockRegister.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/BlockRegister.java
@@ -20,7 +20,7 @@ import net.minecraftforge.registries.RegistryObject;
 
 public class BlockRegister {
     private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, CCCBridge.MOD_ID);
-    private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, CCCBridge.MOD_ID);
+    private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, CCCBridge.MOD_ID);
     private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, CCCBridge.MOD_ID);
 
     public static final RegistryObject<Block> SOURCE_BLOCK = BLOCKS.register("source_block", SourceBlock::new);

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/CCCBridge.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/CCCBridge.java
@@ -4,6 +4,7 @@ import cc.tweaked_programs.cccbridge.display.SourceBlockDisplaySource;
 import cc.tweaked_programs.cccbridge.display.TargetBlockDisplayTarget;
 import com.simibubi.create.content.logistics.block.display.AllDisplayBehaviours;
 import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.ForgeComputerCraftAPI;
 import dan200.computercraft.api.peripheral.IPeripheralProvider;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
@@ -33,14 +34,14 @@ public class CCCBridge {
     @SubscribeEvent
     public static void complete(FMLLoadCompleteEvent event) {
         event.enqueueWork(() -> {
-            AllDisplayBehaviours.assignTile(AllDisplayBehaviours.register(new ResourceLocation(MOD_ID, "source_block_display_source"), new SourceBlockDisplaySource()), BlockRegister.SOURCE_BLOCK_ENTITY.get().delegate);
-            AllDisplayBehaviours.assignTile(AllDisplayBehaviours.register(new ResourceLocation(MOD_ID, "target_block_display_source"), new TargetBlockDisplayTarget()), BlockRegister.TARGET_BLOCK_ENTITY.get().delegate);
+            AllDisplayBehaviours.assignTile(AllDisplayBehaviours.register(new ResourceLocation(MOD_ID, "source_block_display_source"), new SourceBlockDisplaySource()), BlockRegister.SOURCE_BLOCK_ENTITY.get());
+            AllDisplayBehaviours.assignTile(AllDisplayBehaviours.register(new ResourceLocation(MOD_ID, "target_block_display_source"), new TargetBlockDisplayTarget()), BlockRegister.TARGET_BLOCK_ENTITY.get());
 
-            ComputerCraftAPI.registerPeripheralProvider((world, pos, side) -> world.getBlockEntity(pos, BlockRegister.SOURCE_BLOCK_ENTITY.get()).map(be -> be.getPeripheral(side)).map(val -> LazyOptional.of(() -> val)).orElse(LazyOptional.empty()));
-            ComputerCraftAPI.registerPeripheralProvider((world, pos, side) -> world.getBlockEntity(pos, BlockRegister.TARGET_BLOCK_ENTITY.get()).map(be -> be.getPeripheral(side)).map(val -> LazyOptional.of(() -> val)).orElse(LazyOptional.empty()));
-            ComputerCraftAPI.registerPeripheralProvider((world, pos, side) -> world.getBlockEntity(pos,BlockRegister.REDROUTER_BLOCK_ENTITY.get()).map(be -> be.getPeripheral(side)).map(val -> LazyOptional.of(() -> val)).orElse(LazyOptional.empty()));
-            ComputerCraftAPI.registerPeripheralProvider((world, pos, side) -> world.getBlockEntity(pos,BlockRegister.SCROLLER_BLOCK_ENTITY.get()).map(be -> be.getPeripheral(side)).map(val -> LazyOptional.of(() -> val)).orElse(LazyOptional.empty()));
-            ComputerCraftAPI.registerPeripheralProvider(peripheralProvider);
+            ForgeComputerCraftAPI.registerPeripheralProvider((world, pos, side) -> world.getBlockEntity(pos, BlockRegister.SOURCE_BLOCK_ENTITY.get()).map(be -> be.getPeripheral(side)).map(val -> LazyOptional.of(() -> val)).orElse(LazyOptional.empty()));
+            ForgeComputerCraftAPI.registerPeripheralProvider((world, pos, side) -> world.getBlockEntity(pos, BlockRegister.TARGET_BLOCK_ENTITY.get()).map(be -> be.getPeripheral(side)).map(val -> LazyOptional.of(() -> val)).orElse(LazyOptional.empty()));
+            ForgeComputerCraftAPI.registerPeripheralProvider((world, pos, side) -> world.getBlockEntity(pos, BlockRegister.REDROUTER_BLOCK_ENTITY.get()).map(be -> be.getPeripheral(side)).map(val -> LazyOptional.of(() -> val)).orElse(LazyOptional.empty()));
+            ForgeComputerCraftAPI.registerPeripheralProvider((world, pos, side) -> world.getBlockEntity(pos, BlockRegister.SCROLLER_BLOCK_ENTITY.get()).map(be -> be.getPeripheral(side)).map(val -> LazyOptional.of(() -> val)).orElse(LazyOptional.empty()));
+            ForgeComputerCraftAPI.registerPeripheralProvider(peripheralProvider);
         });
     }
 

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/blockEntity/ScrollerBlockEntity.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/blockEntity/ScrollerBlockEntity.java
@@ -8,8 +8,8 @@ import com.simibubi.create.foundation.tileEntity.SmartTileEntity;
 import com.simibubi.create.foundation.tileEntity.TileEntityBehaviour;
 import com.simibubi.create.foundation.tileEntity.behaviour.ValueBoxTransform;
 import com.simibubi.create.foundation.tileEntity.behaviour.scrollvalue.ScrollValueBehaviour;
+import com.simibubi.create.foundation.utility.Lang;
 import com.simibubi.create.foundation.utility.VecHelper;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.phys.Vec3;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import net.minecraft.core.BlockPos;
@@ -88,7 +88,7 @@ public class ScrollerBlockEntity extends SmartTileEntity {
         ScrollValueBehaviour scroller = new ScrollValueBehaviour(this.getBlockState().getBlock().getName(), this, new ControllerValueBoxTransform())
                 .between(-150, 150)
                 .moveText(new Vec3(9, 0, 10))
-                .withUnit(i -> new TranslatableComponent("cccbridge.general.unit.scroller"))
+                .withUnit(i -> Lang.translateDirect("cccbridge.general.unit.scroller"))
                 .withCallback(i -> { if (this.peripheral != null) peripheral.newValue(i); })
                 .onlyActiveWhen(() -> !(this.getLevel().getBlockState(this.getBlockPos()).getValue(BlockStateProperties.LOCKED)))
                 .withStepFunction(context -> context.shift ? 1 : 10)

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/display/SourceBlockDisplaySource.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/display/SourceBlockDisplaySource.java
@@ -4,8 +4,8 @@ import cc.tweaked_programs.cccbridge.blockEntity.SourceBlockEntity;
 import com.simibubi.create.content.logistics.block.display.DisplayLinkContext;
 import com.simibubi.create.content.logistics.block.display.source.DisplaySource;
 import com.simibubi.create.content.logistics.block.display.target.DisplayTargetStats;
+import com.simibubi.create.foundation.utility.Lang;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 import java.util.LinkedList;
@@ -25,7 +25,7 @@ public class SourceBlockDisplaySource extends DisplaySource {
 
         List<MutableComponent> content = new LinkedList<>();
         for (String line : data) {
-            content.add(new TextComponent("").append(line));
+            content.add(Lang.translateDirect("").append(line));
         }
 
         return content;

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/peripherals/TrainPeripheral.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/peripherals/TrainPeripheral.java
@@ -8,13 +8,13 @@ import com.simibubi.create.content.logistics.trains.management.edgePoint.station
 import com.simibubi.create.content.logistics.trains.management.edgePoint.station.TrainEditPacket.TrainEditReturnPacket;
 import com.simibubi.create.content.logistics.trains.management.schedule.Schedule;
 import com.simibubi.create.foundation.networking.AllPackets;
+import com.simibubi.create.foundation.utility.Lang;
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.lua.MethodResult;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.network.PacketDistributor;
 import org.jetbrains.annotations.NotNull;
@@ -103,7 +103,7 @@ public class TrainPeripheral implements IPeripheral {
      */
     @LuaFunction
     public final String getTrainName() {
-        return Objects.requireNonNull(station.getStation().getPresentTrain()).name.getContents();
+        return Objects.requireNonNull(station.getStation().getPresentTrain()).name.getString();
     }
 
     /**
@@ -144,7 +144,7 @@ public class TrainPeripheral implements IPeripheral {
             return MethodResult.of(false, "Train not found");
         }
         if (!name.isBlank()) {
-            Train.name = new TextComponent(name);
+            Train.name = Lang.translateDirect(name);
             station.tick();
             AllPackets.channel.send(PacketDistributor.ALL.noArg(), new TrainEditReturnPacket(Train.id, name, Train.icon.getId()));
             return MethodResult.of(true, "Train name set to" + name);

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/peripherals/TrainPeripheral.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/peripherals/TrainPeripheral.java
@@ -99,11 +99,15 @@ public class TrainPeripheral implements IPeripheral {
     /**
      * Returns the current trains name.
      *
-     * @return Name of train.
+     * @return @return Whether it was successful or not with the train's name.
      */
     @LuaFunction
-    public final String getTrainName() {
-        return Objects.requireNonNull(station.getStation().getPresentTrain()).name.getContents();
+    public final MethodResult getTrainName() {
+        if (station.getStation().getPresentTrain() == null) {
+            return MethodResult.of(false, "There is no assembled train to get the name of");
+        }else {
+            return MethodResult.of(true, Objects.requireNonNull(station.getStation().getPresentTrain()).name.getContents());
+        }
     }
 
     /**
@@ -154,12 +158,12 @@ public class TrainPeripheral implements IPeripheral {
     }
 
     /**
-     * Gets the number of Bogeys attached to the current train.
+     * Gets the number of Carriages attached to the current train.
      *
-     * @return The number of Bogeys.
+     * @return The number of Carriages.
      */
     @LuaFunction
-    public final int getBogeys() {
+    public final int getCarriageCount() {
         if (station.getStation().getPresentTrain() == null) {
             return 0;
         }

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -31,7 +31,7 @@ Copyright 2022 Sammy L. Koch'''
 [[dependencies.cccbridge]]
     modId="create"
     mandatory=true
-    versionRange="[0.5.0c,)"
+    versionRange="[0.5.0e,)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.cccbridge]]

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -19,24 +19,24 @@ Copyright 2022 Sammy L. Koch'''
 [[dependencies.cccbridge]]
     modId="forge"
     mandatory=true
-    versionRange="[40,)"
+    versionRange="[43.1,)"
     ordering="NONE" # NONE; BEFORE; AFTER
     side="BOTH"
 [[dependencies.cccbridge]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.18.2,1.19)"
+    versionRange="[1.19.2,)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.cccbridge]]
     modId="create"
     mandatory=true
-    versionRange="[0.5.0c,)"
+    versionRange="[0.5.0f,)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.cccbridge]]
     modId="computercraft"
     mandatory=true
-    versionRange="[1.101.0,)"
+    versionRange="[1.101.1,)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
Hi,
I noticed the conversation in #12, so I decided to update the mod and open a PR. There are a few deprecation warnings mostly to do with the computercraft API, but for now the mod works on 1.19.2 on both Fabric and Forge. You'll probably want to bump the version number up in the gradle.properties as I left this alone. 

I also fixed a few little bugs with the train station peripheral for both Forge and Fabric. The first was if you tried to get the train's name while there was no train present, it would throw an exception in Java. The other smaller bug was the getBogeys function returned the number of carriages, so I changed the name of this function to GetCarriageCount. I would have made it so it returned the bogey count but I couldn't find an easy way to do this, so the documentation / wiki might need updating to reflect this.