### PR TITLE
Fixed typos, improved grammar and consistency of the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /fabric/.idea/
 /fabric/package.json
 /fabric/package-lock.json
+
+# MkDocs
+.cache

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,6 +1,6 @@
 # Guides
 
-Here are some guides that may be helpful.
+Here are some guides that might be helpful.
 
 | Title | Description |
 |-------|-------------|

--- a/docs/guides/positioningAnimatronicAnalog.md
+++ b/docs/guides/positioningAnimatronicAnalog.md
@@ -5,7 +5,7 @@ However, some people might not want to use _another Computer_, just to position 
 
 But the Animatronic **can actually be used without a Computer**.
 
-## Viewing rotation
+## Viewing Rotation
 
 **To take a look at the current pose of an Animatronic**, simply run the following command in Minecraft:
 ```mcfunction
@@ -13,7 +13,7 @@ data get block <x> <y> <z>
 ```
 _The coordinates here represent where the Animatronic is standing._
 
-## Changing rotation
+## Changing Rotation
 
 To change the rotation of a body part, you can run a similar command in Minecraft:
 ```mcfunction

--- a/docs/guides/positioningAnimatronicAnalog.md
+++ b/docs/guides/positioningAnimatronicAnalog.md
@@ -1,9 +1,9 @@
 # Using Animatronics: The Analog Way
 
-Animatronics are originally meant to be controlled within a Computer.
+Animatronics are normally controlled by a Computer.
 However, some people might not want to use _another Computer_, just to position it once. Others might not know how to use CC: Tweaked at all and can't use it because of this.
 
-But the Animatronic **can be used without one Computer** actually.
+But the Animatronic **can actually be used without a Computer**.
 
 ## Viewing rotation
 
@@ -15,7 +15,7 @@ _The coordinates here represent where the Animatronic is standing._
 
 ## Changing rotation
 
-To change a rotation of one body part, you can run a similar command in Minecraft:
+To change the rotation of a body part, you can run a similar command in Minecraft:
 ```mcfunction
 data modify block <x> <y> <z> <body_part> set value [<rot_x>, <rot_y>, <rot_z>]
 ```

--- a/docs/guides/wrenches.md
+++ b/docs/guides/wrenches.md
@@ -1,15 +1,15 @@
 # Wrenches and You
 
 Some blocks have the ability to be manipulated via the **Wrench from Create**.  
-This mod has this integrated as well for the RedRouter Block and Animatronic.
+This mod also implements this feature for the RedRouter Block and Animatronics.
 
-## Right click
+## Right Click
 By right clicking on the blocks upwards or downwards facing side, you can **rotate them horizontally**.
 The RedRouter Block can be rotated in **90° steps**, while the Animatronic can be rotated in **45° steps**.
 
 !!! note
-    The Animatronic's rotation can be set to **any number from 0° to 360°** by manipulating the **blockstate** using the **Debug Stick** or the `/setblock` command.
+    The Animatronic's rotation can be set to **any number from 0° to 360°** by manipulating the **block state** using the **Debug Stick** or the `/setblock` command.
 
-## Shift right click
+## Shift + Right Click
 
-By shift right clicking, both the **RedRouter Block and the Animatronic can be  removed** and placed **in your inventory instantly**.
+By pressing shift and right clicking, both the **RedRouter Block and the Animatronic can be  removed** and placed **in your inventory instantly**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,4 +19,4 @@ If you are new to CC: Tweaked or Lua programming in general, consider to take a 
 [ :material-calculator-variant-outline: Guides :material-calculator-variant-outline: ](guides/index.md){ .md-button .md-button--primary .md-button-right }
 
 [ :octicons-x-circle-24: Issue Tracker :octicons-x-circle-24: ](https://github.com/tweaked-programs/cccbridge/issues){ .md-button }
-[ :fontawesome-brands-github-alt: GitHub :fontawesome-brands-github-alt: ](#https://github.com/tweaked-programs/cccbridge){ .md-button .md-button-right }
+[ :fontawesome-brands-github-alt: GitHub :fontawesome-brands-github-alt: ](https://github.com/tweaked-programs/cccbridge){ .md-button .md-button-right }

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ _This mod allows you to write [Lua](https://www.lua.org/start.html) scripts in [
 
 ## Programming for beginners
 
-If you are new to CC: Tweaked or Lua programming in general, consider to take a look at the following ancent _(but still usable)_ resources:
+If you are new to CC: Tweaked or Lua programming in general, consider to take a look at the following ancient _(but still usable)_ resources:
 
  * [SethBling - "Programming Tutorial with Minecraft Turtles"](https://youtu.be/DSsx4VSe-Uk) on YouTube,
  * [Direwolf20's ComputerCraft tutorials](https://youtube.com/playlist?list=PLaiPn4ewcbkHYflo2jl0OuNaHK6Mj-koG) series on YouTube as well and

--- a/docs/peripherals/AnimatronicPeripheral.md
+++ b/docs/peripherals/AnimatronicPeripheral.md
@@ -37,52 +37,52 @@ After pushing them, every rotation gets reset to `0`.
 
 ### `setHeadRot(x, y, z)`
 Sets the head rotation.  
-Can only be set within the bounds -180° to 180° for `X`, `Y` and `Z`.
+Can only be set within the bounds -180° to 180° for `x`, `y` and `z`.
 
 **Parameters**
 
- 1. `x`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The X rotation.
- 2. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The Y rotation.
- 3. `z`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The Z rotation.
+ 1. `x`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `x` rotation.
+ 2. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `y` rotation.
+ 3. `z`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `z` rotation.
 
 ---
 
 ### `setBodyRot(x, y, z)`
 Sets the body rotation.  
-Can only be set within the bounds -180° to 180° for `Y` and `Z`.
+Can only be set within the bounds -180° to 180° for `y` and `z`.
 
 !!! info
-    `X` can be set to any number within 360°.
+    `x` can be set to any number within 360°.
 
 **Parameters**
 
- 1. `x`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The X rotation.
- 2. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The Y rotation.
- 3. `z`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The Z rotation.
+ 1. `x`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `x` rotation.
+ 2. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `y` rotation.
+ 3. `z`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `z` rotation.
 
 ---
 
 ### `setLeftArmRot(x, y, z)`
 Sets the left arm rotation.  
-Can only be set within the bounds -180° to 180° for `X`, `Y` and `Z`.
+Can only be set within the bounds -180° to 180° for `x`, `y` and `z`.
 
 **Parameters**
 
- 1. `x`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The X rotation.
- 2. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The Y rotation.
- 3. `z`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The Z rotation.
+ 1. `x`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `x` rotation.
+ 2. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `y` rotation.
+ 3. `z`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `z` rotation.
 
 ---
 
 ### `setRightArmRot(x, y, z)`
 Sets the right arm rotation.  
-Can only be set within the bounds -180° to 180° for `X`, `Y` and `Z`.
+Can only be set within the bounds -180° to 180° for `x`, `y` and `z`.
 
 **Parameters**
 
- 1. `x`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The X rotation.
- 2. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The Y rotation.
- 3. `z`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The Z rotation.
+ 1. `x`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `x` rotation.
+ 2. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `y` rotation.
+ 3. `z`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `z` rotation.
 
 ---
 
@@ -90,9 +90,9 @@ Can only be set within the bounds -180° to 180° for `X`, `Y` and `Z`.
 Returns the current stored head rotation.
 
 **Returns**
- 1. `number` The X rotation
- 2. `number` The Y rotation
- 3. `number` The Z rotation
+ 1. `number` The `x` rotation
+ 2. `number` The `y` rotation
+ 3. `number` The `z` rotation
 
 ---
 
@@ -100,9 +100,9 @@ Returns the current stored head rotation.
 Returns the current stored body rotation.
 
 **Returns**
- 1. `number` The X rotation
- 2. `number` The Y rotation
- 3. `number` The Z rotation
+ 1. `number` The `x` rotation
+ 2. `number` The `y` rotation
+ 3. `number` The `z` rotation
 
 ---
 
@@ -110,9 +110,9 @@ Returns the current stored body rotation.
 Returns the current stored left arm rotation.
 
 **Returns**
- 1. `number` The X rotation
- 2. `number` The Y rotation
- 3. `number` The Z rotation
+ 1. `number` The `x` rotation
+ 2. `number` The `y` rotation
+ 3. `number` The `z` rotation
 
 ---
 
@@ -120,9 +120,9 @@ Returns the current stored left arm rotation.
 Returns the current stored right arm rotation.
 
 **Returns**
- 1. `number` The X rotation
- 2. `number` The Y rotation
- 3. `number` The Z rotation
+ 1. `number` The `x` rotation
+ 2. `number` The `y` rotation
+ 3. `number` The `z` rotation
 
 ---
 
@@ -130,9 +130,9 @@ Returns the current stored right arm rotation.
 Returns the rotation of the head.
 
 **Returns**
- 1. `number` The X rotation
- 2. `number` The Y rotation
- 3. `number` The Z rotation
+ 1. `number` The `x` rotation
+ 2. `number` The `y` rotation
+ 3. `number` The `z` rotation
 
 ---
 
@@ -140,9 +140,9 @@ Returns the rotation of the head.
 Returns the rotation of the body.
 
 **Returns**
- 1. `number` The X rotation
- 2. `number` The Y rotation
- 3. `number` The Z rotation
+ 1. `number` The `x` rotation
+ 2. `number` The `y` rotation
+ 3. `number` The `z` rotation
 
 ---
 
@@ -150,9 +150,9 @@ Returns the rotation of the body.
 Returns the rotation of the left arm.
 
 **Returns**
- 1. `number` The X rotation
- 2. `number` The Y rotation
- 3. `number` The Z rotation
+ 1. `number` The `x` rotation
+ 2. `number` The `y` rotation
+ 3. `number` The `z` rotation
 
 ---
 
@@ -160,6 +160,6 @@ Returns the rotation of the left arm.
 Returns the rotation of the right arm.
 
 **Returns**
- 1. `number` The X rotation
- 2. `number` The Y rotation
- 3. `number` The Z rotation
+ 1. `number` The `x` rotation
+ 2. `number` The `y` rotation
+ 3. `number` The `z` rotation

--- a/docs/peripherals/AnimatronicPeripheral.md
+++ b/docs/peripherals/AnimatronicPeripheral.md
@@ -1,9 +1,9 @@
 # Animatronic
 
 ![Image title](../assets/images/peripherals/animatronic_block.png){ align=left width="65" }
-This peripheral is used by the Animatronic. It is an electronic puppet that can be positioned however needed.
+This peripheral is provided by the Animatronic. It is an electronic puppet that can be positioned however needed.
 
-The transition from one pose to a new one is fully automatic. And rusty.
+The transition from one pose to a new one is fully automatic - and rusty.
 
 ## Metadata
 
@@ -49,10 +49,10 @@ Can only be set within the bounds -180° to 180° for `X`, `Y` and `Z`.
 
 ### `setBodyRot(x, y, z)`
 Sets the body rotation.  
-Can only be set within the bounds -180° to 180° for `X`, `Y` and `Z`.
+Can only be set within the bounds -180° to 180° for `Y` and `Z`.
 
 !!! info
-    `X` can be set within 360°.
+    `X` can be set to any number within 360°.
 
 **Parameters**
 

--- a/docs/peripherals/RedRouterBlockPeripheral.md
+++ b/docs/peripherals/RedRouterBlockPeripheral.md
@@ -50,7 +50,7 @@ Set a redstone signal strength for a specific side.
 ---
 
 ### `getOutput(side)`
-Get the current redstone output of a specific side. *(see ``setOutput``)*  
+Get the current redstone output of a specific side. *(see `setOutput`)*  
 
 **Parameters**
 
@@ -76,7 +76,7 @@ Get the current redstone input of a specific side.
 ---
 
 ### `getAnalogOutput(side)`
-Get the redstone output signal strength for a specific side.  *(see ``setAnalogOutput``)*  
+Get the redstone output signal strength for a specific side.  *(see `setAnalogOutput`)*  
 
 **Parameters**
 

--- a/docs/peripherals/RedRouterBlockPeripheral.md
+++ b/docs/peripherals/RedRouterBlockPeripheral.md
@@ -19,7 +19,7 @@ The RedRouter can send the following event:
 
 | Name | Description | Parameter 1 |
 |------|-------------|-------------|
-| `"redstone"` | Whenever a redstone signal has changed. | `string`: **attatched_name** |
+| `"redstone"` | Whenever a redstone signal has changed. | `string`: **attached_name** |
 
 ---
 

--- a/docs/peripherals/RedRouterBlockPeripheral.md
+++ b/docs/peripherals/RedRouterBlockPeripheral.md
@@ -1,10 +1,10 @@
 # RedRouter Block
 
 ![Image title](../assets/images/peripherals/redrouter_block.png){ align=left width="100" }
-This peripheral is used by the **RedRouter Block**. It is used to control redstone signals.
+This peripheral is provided by the **RedRouter Block**. It is used to control redstone signals.
 
-The peripheral acts similar to the [Redstone API](https://tweaked.cc/module/redstone.html) with some exceptions like bundled cable support.  
-The sides are configured similar to the turtle, where `"left"` is **relative to the blocks facing.**
+The peripheral acts similar to the [Redstone API](https://tweaked.cc/module/redstone.html) with some exceptions like missing bundled cable support.  
+The sides are configured similarly to the turtle, where `"left"` is **relative to the blocks facing.**
 
 ## Metadata
 
@@ -26,7 +26,7 @@ The RedRouter can send the following event:
 ## Functions
 
 ### `setOutput(side, on)`
-Toggles a redstone signal for a specific side.  
+Set a redstone signal for a specific side.  
 
 **Parameters**
 

--- a/docs/peripherals/ScrollerBlockPeripheral.md
+++ b/docs/peripherals/ScrollerBlockPeripheral.md
@@ -3,7 +3,7 @@
 ![Image title](../assets/images/peripherals/scroller_block.png){ align=left width="65" }
 This peripheral is provided by the **Scroller Pane**. It allows players to provide an input as an number inside the world. The interface can be manipulated.
 
-The peripheral uses Create's NumberBehaviour selection screen. _(The same one you see when you for example adjust the speed on an **RotationalSpeedController**)_
+The peripheral uses Create's `NumberBehaviour` selection screen. _(The same one you see when you for example adjust the speed on an **RotationalSpeedController**)_
 
 ## Metadata
 
@@ -18,7 +18,7 @@ The RedRouter can send the following event:
 
 | Name | Description | Parameter 1 | Parameter 2 |
 |------|-------------|-------------|-------------|
-| `"scroller_changed"` | Whenever the value got changed by a player. | `string`: **attatched_name** | `number`: **new_value** |
+| `"scroller_changed"` | Whenever the value got changed by a player. | `string`: **attached_name** | `number`: **new_value** |
 
 !!! warning
     The event `"scroller_changed"` also fires when the value gets changed by an Computer. This is a bug that will be fixed!

--- a/docs/peripherals/ScrollerBlockPeripheral.md
+++ b/docs/peripherals/ScrollerBlockPeripheral.md
@@ -1,9 +1,9 @@
 # Scroller Pane
 
 ![Image title](../assets/images/peripherals/scroller_block.png){ align=left width="65" }
-This peripheral is used by the **Scroller Pane**. It allows players to provide an input as an number inside the world. The interface can be manipulated.
+This peripheral is provided by the **Scroller Pane**. It allows players to provide an input as an number inside the world. The interface can be manipulated.
 
-The peripheral uses Create's NumberBehaviour selection screen. _(The same one you see whenever you e.g. adjust the speed on an **RotationalSpeedController**)_
+The peripheral uses Create's NumberBehaviour selection screen. _(The same one you see when you for example adjust the speed on an **RotationalSpeedController**)_
 
 ## Metadata
 
@@ -18,7 +18,7 @@ The RedRouter can send the following event:
 
 | Name | Description | Parameter 1 | Parameter 2 |
 |------|-------------|-------------|-------------|
-| `"scroller_changed"` | Whenever the value got changed by a player.* | `string`: **attatched_name** | `number`: **new_value** |
+| `"scroller_changed"` | Whenever the value got changed by a player. | `string`: **attatched_name** | `number`: **new_value** |
 
 !!! warning
     The event `"scroller_changed"` also fires when the value gets changed by an Computer. This is a bug that will be fixed!
@@ -37,11 +37,11 @@ Returns whether the Scroller Pane is locked or not.
 ---
 
 ### `setLock(state)`
-Unlocks the Scroller Pane with state = false (default) or state = true so that players cannot continue to use it.
+Unlocks the Scroller Pane with `state = false` (default) or locks it with `state = true` so that players cannot continue to use it.
 
 **Parameters**
 
- 1. `state`: [boolean](https://www.lua.org/manual/5.1/manual.html#2.2) Whenever the lock should be active or disabled.
+ 1. `state`: [boolean](https://www.lua.org/manual/5.1/manual.html#2.2) Wether the lock should be active or disabled.
 
 ---
 ### `getValue()`
@@ -72,7 +72,7 @@ Returns the limit relative to zero.
 ---
 
 ### `hasMinusSpectrum()`
-Returns whenever the Scroller Pane has the minus spectrum enabled.
+Returns wether the Scroller Pane has the minus spectrum enabled.
 
 **Returns**
 

--- a/docs/peripherals/SourceBlockPeripheral.md
+++ b/docs/peripherals/SourceBlockPeripheral.md
@@ -18,7 +18,7 @@ The RedRouter can send the following event:
 
 | Name | Description | Parameter 1 |
 |------|-------------|-------------|
-| `"monitor_resize"` | Whenever the display targets size changes. | `string`: **attatched_name** |
+| `"monitor_resize"` | Whenever the display targets size changes. | `string`: **attached_name** |
 
 ---
 

--- a/docs/peripherals/SourceBlockPeripheral.md
+++ b/docs/peripherals/SourceBlockPeripheral.md
@@ -29,8 +29,8 @@ Sets the position of the cursor. `write` will begin at this position.
 
 **Parameters**
 
- 1. `x`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The new x position of the cursor.  
- 2. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The new y position of the cursor.  
+ 1. `x`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The new `x` position of the cursor.  
+ 2. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The new `y` position of the cursor.  
 
 ---
 
@@ -66,7 +66,7 @@ Returns the line at the wanted display position.
 
 **Parameters**
 
- 1. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The y position on the display.  
+ 1. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `y` position on the display.  
 
 **Returns**
 
@@ -83,8 +83,8 @@ Returns the current cursor position.
 
 **Returns**
 
- 1. `number` The **x** position of the cursor.  
- 2. `number` The **y** position of the cursor. 
+ 1. `number` The `x` position of the cursor.  
+ 2. `number` The `y` position of the cursor. 
 
 ---
 

--- a/docs/peripherals/SourceBlockPeripheral.md
+++ b/docs/peripherals/SourceBlockPeripheral.md
@@ -1,7 +1,7 @@
 # Source Block
 
 ![Image title](../assets/images/peripherals/source_block.png){ align=left width="100" }
-This peripheral is used by the **Source Block**. It is used to display data on **Create Display Targets**.
+This peripheral is provided by the **Source Block**. It is used to display data on **Create Display Targets**.
 
 The peripheral acts similar to a normal [Terminal](https://tweaked.cc/module/term.html) with some implementations from the [Window API](https://tweaked.cc/module/window.html). It does not support formatted text.
 
@@ -39,7 +39,7 @@ Will write the given input to the linked display.
 
 **Parameters**
 
- 1. `text`: [string](https://www.lua.org/manual/5.1/manual.html#5.4) The string to write on the current cursor position.  
+ 1. `text`: [string](https://www.lua.org/manual/5.1/manual.html#5.4) The string to write at the current cursor position.  
 
 ---
 ### `scroll(y)`
@@ -47,7 +47,7 @@ Scrolls the content of the display vertically for `y` lines.
 
 **Parameters**
 
- 1. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) How many lines will the display scroll.  
+ 1. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) How many lines the display will scroll.  
 
 ---
 

--- a/docs/peripherals/TargetBlockPeripheral.md
+++ b/docs/peripherals/TargetBlockPeripheral.md
@@ -1,9 +1,9 @@
 # Target Block
 
 ![Image title](../assets/images/peripherals/target_block.png){ align=left width="100" }
-This peripheral is used by the **Target Block**. It is used to get data from **Create Display Sources**.
+This peripheral is provided by the **Target Block**. It is used to get data from **Create Display Sources**.
 
-The peripheral only has some implementations from the [Window API](https://tweaked.cc/module/window.html) to receive data. It can't be much manipulated manipulated.
+The peripheral only has some implementations from the [Window API](https://tweaked.cc/module/window.html) to receive data. It can't be manipulated much.
 
 ## Metadata
 
@@ -25,7 +25,7 @@ Sets the new width of the display. Cannot be larger than 164 chars.
 
 **Throws**
 
- 1. Whenever the given number is not in the range from `1` to `164`.  
+ 1. Whenever the given number is not in the range `1` to `164`.  
 
 ---
 
@@ -56,7 +56,7 @@ Returns the line at the wanted display position.
 
 **Throws**
 
- 1. Whenever the given number is not in the range from `1` to `<terminal height>`  
+ 1. Whenever the given number is not in the range `1` to `<terminal height>`  
 
 ---
 

--- a/docs/peripherals/TargetBlockPeripheral.md
+++ b/docs/peripherals/TargetBlockPeripheral.md
@@ -39,7 +39,7 @@ Clears the line at the cursor position.
 
 **Parameters**
 
- 1. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The Y position of the to be cleared line.  
+ 1. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `y` position of the to be cleared line.  
 
 ---
 
@@ -48,11 +48,11 @@ Returns the line at the wanted display position.
 
 **Parameters**
 
- 1. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The y position on the display.  
+ 1. `y`: [number](https://www.lua.org/manual/5.1/manual.html#2.2) The `y` position on the display.  
 
 **Returns**
 
- 1. `string` The string from the given Y position.  
+ 1. `string` The string from the given `y` position.  
 
 **Throws**
 

--- a/docs/peripherals/index.md
+++ b/docs/peripherals/index.md
@@ -8,4 +8,4 @@ This section contains the API documentation.
 | [**RedRouter Block**](RedRouterBlockPeripheral.md) | Sends and receives redstone signals. |
 | [**Target Block**](TargetBlockPeripheral.md) | Simulates a **Create Display Target** to receive data from **Create Display Sources**. |
 | [**Scroller Pane**](ScrollerBlockPeripheral.md) | Provides an interface to select a number form a given spectrum. |
-| [**Animatronic**](AnimatronicPeripheral.md) | Controlls an Animatronic's body and face expression _(Similar to Armor Stands)_ |
+| [**Animatronic**](AnimatronicPeripheral.md) | Controls an Animatronic's body and face expression _(Similar to Armor Stands)_ |

--- a/docs/peripherals/index.md
+++ b/docs/peripherals/index.md
@@ -5,7 +5,7 @@ This section contains the API documentation.
 | Type | Description |
 |-|-|
 | [**Source Block**](SourceBlockPeripheral.md) | Transmits text to any kind of display that works with **Create**. |
-| [**RedRouter Block**](RedRouterBlockPeripheral.md) | Sends and receive redstone signals. |
+| [**RedRouter Block**](RedRouterBlockPeripheral.md) | Sends and receives redstone signals. |
 | [**Target Block**](TargetBlockPeripheral.md) | Simulates a **Create Display Target** to receive data from **Create Display Sources**. |
 | [**Scroller Pane**](ScrollerBlockPeripheral.md) | Provides an interface to select a number form a given spectrum. |
 | [**Animatronic**](AnimatronicPeripheral.md) | Controlls an Animatronic's body and face expression _(Similar to Armor Stands)_ |


### PR DESCRIPTION
## Goals of this PR

- Adding the MkDocs cache folder to the `.gitignore`
- Fixing several typos throughout the documentation, improving grammar and consistency 
- Fixing the GitHub link on the main page of the documentation

## Limitations of this PR

- I tried keeping opinionated changes to grammar and wording to a minimum - These belong in a separate follow-up PR.
- I likely have not fixed every typo or grammar mistake in the documentation, partially due to oversight, partially due to the aforementioned limitation. Therefore, **I'd like to request a review by somebody else than me** 
