### PR TITLE
v1.6.1 bug fixes

### DIFF
--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Mod Properties
-mod_version=1.6.0
+mod_version=1.6.1
 maven_group=cc.tweaked_programs
 archives_base_name=cccbridge
 
@@ -19,7 +19,7 @@ parchment_version=2023.07.16
 # Dependencies
 fabric_version=0.86.0
 cc_version=1.106.1
-create_version=0.5.1-c-build.1113
+create_version=0.5.1-d-build.1130
 create_version_production=0.5.1-c
 
 # Mod Menu - https://modrinth.com/mod/modmenu/versions

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/computercraft/peripherals/ScrollerBlockPeripheral.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/computercraft/peripherals/ScrollerBlockPeripheral.java
@@ -71,8 +71,10 @@ public class ScrollerBlockPeripheral extends TweakedPeripheral<ScrollerBlockEnti
     @LuaFunction
     public final void setValue(int value) {
         ScrollerBlockEntity be = getTarget();
-        if (be != null)
+        if (be != null) {
+            be.nextChangeQuietly();
             be.setValue(value);
+        }
     }
 
     /**

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/block/RedRouterBlock.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/block/RedRouterBlock.java
@@ -26,7 +26,7 @@ import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import org.jetbrains.annotations.NotNull;
 
 public class RedRouterBlock extends HorizontalDirectionalBlock implements EntityBlock, IWrenchable {
-    public static final Properties REDROUTER_BLOCK_PROPERTIES = FabricBlockSettings.create().strength(1.3f).sound(SoundType.STONE).noOcclusion();
+    public static final Properties REDROUTER_BLOCK_PROPERTIES = FabricBlockSettings.create().strength(1.3f).sound(SoundType.STONE).noOcclusion().isRedstoneConductor((state, view, pos) -> false);
     public static final int FACE_AMOUNT = 16;
     public static final IntegerProperty FACE = IntegerProperty.create("face", 0, FACE_AMOUNT);
     public RedRouterBlock(Properties properties) {
@@ -71,6 +71,11 @@ public class RedRouterBlock extends HorizontalDirectionalBlock implements Entity
         if (!(block instanceof RedRouterBlockEntity redrouter))
             return 0;
         return redrouter.getPower(dir);
+    }
+
+    @Override
+    public int getDirectSignal(BlockState state, BlockGetter level, BlockPos pos, Direction direction) {
+        return getSignal(state, level, pos, direction);
     }
 
     @Override

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/ScrollerBlockEntity.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/ScrollerBlockEntity.java
@@ -27,8 +27,8 @@ import java.util.List;
 public class ScrollerBlockEntity extends SmartBlockEntity implements PeripheralBlockEntity {
     private ScrollerBlockPeripheral peripheral;
     private boolean locked = false;
+    private boolean quietly = false;
     private boolean updateLock = false;
-    private boolean playTickSound = false;
     private LuaScrollValueBehaviour scroller;
 
     public ScrollerBlockEntity(BlockPos pos, BlockState state) {
@@ -54,8 +54,16 @@ public class ScrollerBlockEntity extends SmartBlockEntity implements PeripheralB
         scroller.setValue(value);
     }
 
+    public void nextChangeQuietly() {
+        quietly = true;
+    }
+
     public void fireUpdateValueEvent() {
-        if (peripheral != null)
+        if (quietly) {
+            quietly = false;
+            return;
+        }
+        if (peripheral != null )
             peripheral.sendEvent("scroller_changed", scroller.getValue());
     }
 
@@ -73,16 +81,6 @@ public class ScrollerBlockEntity extends SmartBlockEntity implements PeripheralB
                     1.5f);
             world.setBlock(blockPos, state.setValue(BlockStateProperties.LOCKED, scroller.locked), 19); // 19 = BLOCK_UPDATE_FLAGS
             scroller.updateLock = false;
-        }
-        if (scroller.playTickSound) {
-            world.playSound(
-                    null,
-                    blockPos,
-                    AllSoundEvents.SCROLL_VALUE.getMainEvent(),
-                    SoundSource.BLOCKS,
-                    0.25f,
-                    1.5f);
-            scroller.playTickSound = false;
         }
     }
 

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/mixin/MixinAdventureUtil.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/mixin/MixinAdventureUtil.java
@@ -1,0 +1,32 @@
+package cc.tweaked_programs.cccbridge.common.mixin;
+
+import cc.tweaked_programs.cccbridge.common.minecraft.blockEntity.ScrollerBlockEntity;
+import com.simibubi.create.foundation.utility.AdventureUtil;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(AdventureUtil.class)
+public abstract class MixinAdventureUtil {
+    @Inject(method = "isAdventure", at = @At("HEAD"), cancellable = true, remap = false)
+    private static void cccbridge$isAdventure(Player player, CallbackInfoReturnable<Boolean> cir) {
+        if (player.isSpectator())
+            return;
+
+        Level level = player.level();
+        HitResult hitResult = player.pick(5, 1, false);
+
+        if (hitResult instanceof BlockHitResult blockHit) {
+            BlockEntity blockEntity = level.getBlockEntity(blockHit.getBlockPos());
+
+            if (blockEntity instanceof ScrollerBlockEntity)
+                cir.setReturnValue(false);
+        }
+    }
+}

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/mixin/MixinCarriageContraption.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/mixin/MixinCarriageContraption.java
@@ -18,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.List;
 
 @Mixin(CarriageContraption.class)
-public abstract class CarriageContraptionMixin extends Contraption {
+public abstract class MixinCarriageContraption extends Contraption {
     @Shadow
     private List<BlockPos> assembledBlazeBurners;
 

--- a/fabric/src/main/resources/cccbridge.mixins.json
+++ b/fabric/src/main/resources/cccbridge.mixins.json
@@ -4,7 +4,8 @@
   "package": "cc.tweaked_programs.cccbridge.common.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "CarriageContraptionMixin"
+    "MixinCarriageContraption",
+    "MixinAdventureUtil"
   ],
   "client": [
   ],


### PR DESCRIPTION
**This small PR updates some small bugs:**

- RedRouter Blocks can't conduct outside redstone signals anymore & now will emit strong redstone signals when one side is powered.
- Scroller Panes now can be used in Adventure mode as well.
  - They also won't push a `"scroller_changed"` event anymore, when a Computer changes the value.
- Create dependency's version got updated to something that makes more sense