### PR TITLE
Fixed RedRouter UVs

### DIFF
--- a/fabric/src/main/resources/assets/cccbridge/models/block/redrouter_block.json
+++ b/fabric/src/main/resources/assets/cccbridge/models/block/redrouter_block.json
@@ -118,11 +118,11 @@
 			"from": [0, 0, 2],
 			"to": [16, 16, 16],
 			"faces": {
-				"east": {"uv": [0, 0, 15, 16], "texture": "#3", "cullface": "east"},
+				"east": {"uv": [0, 0, 14, 16], "texture": "#3", "cullface": "east"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#3", "cullface": "south"},
-				"west": {"uv": [1, 0, 16, 16], "texture": "#3", "cullface": "west"},
-				"up": {"uv": [0, 1, 16, 16], "texture": "#4"},
-				"down": {"uv": [0, 0, 16, 15], "texture": "#4"}
+				"west": {"uv": [2, 0, 16, 16], "texture": "#3", "cullface": "west"},
+				"up": {"uv": [0, 2, 16, 16], "texture": "#4"},
+				"down": {"uv": [0, 0, 16, 14], "texture": "#4"}
 			}
 		},
 		{

--- a/forge/src/main/resources/assets/cccbridge/models/block/redrouter_block.json
+++ b/forge/src/main/resources/assets/cccbridge/models/block/redrouter_block.json
@@ -118,11 +118,11 @@
 			"from": [0, 0, 2],
 			"to": [16, 16, 16],
 			"faces": {
-				"east": {"uv": [0, 0, 15, 16], "texture": "#3", "cullface": "east"},
+				"east": {"uv": [0, 0, 14, 16], "texture": "#3", "cullface": "east"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#3", "cullface": "south"},
-				"west": {"uv": [1, 0, 16, 16], "texture": "#3", "cullface": "west"},
-				"up": {"uv": [0, 1, 16, 16], "texture": "#4"},
-				"down": {"uv": [0, 0, 16, 15], "texture": "#4"}
+				"west": {"uv": [2, 0, 16, 16], "texture": "#3", "cullface": "west"},
+				"up": {"uv": [0, 2, 16, 16], "texture": "#4"},
+				"down": {"uv": [0, 0, 16, 14], "texture": "#4"}
 			}
 		},
 		{


### PR DESCRIPTION
I noticed the body of the RedRouter had an extra pixel in the UV, making it a total of 17 pixels long.

Before:
![before](https://github.com/tweaked-programs/cccbridge/assets/108158093/67b5055a-c89d-46f0-b040-5ead49e38381)

After:
![after](https://github.com/tweaked-programs/cccbridge/assets/108158093/49338b84-4639-4251-a20e-73417f994b82)
