### PR TITLE
New feature: Animation Modes

### DIFF
--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/computercraft/peripherals/AnimatronicPeripheral.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/computercraft/peripherals/AnimatronicPeripheral.java
@@ -23,7 +23,6 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     private float[] bodyRot;
     private float[] leftArmRot;
     private float[] rightArmRot;
-    private boolean shouldAnimate;
 
     public AnimatronicPeripheral(AnimatronicBlockEntity blockEntity) {
         super("animatronic",blockEntity);
@@ -32,7 +31,6 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
         bodyRot = new float[]{0,0,0};
         leftArmRot = new float[]{0,0,0};
         rightArmRot = new float[]{0,0,0};
-        shouldAnimate = true;
     }
 
     /**
@@ -54,19 +52,19 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     }
 
     /**
-     * Sets if there should be easing between poses.
+     * Sets the Animatronic animation mode.
+     *
+     * @param mode The new mode. Must be either 'raw' or 'rusty'.
+     *
+     * @throws LuaException Whenever the given string is not one of those types.
      */
     @LuaFunction
-    public final void setShouldAnimate(boolean shouldAnimate) {
-        this.shouldAnimate = shouldAnimate;
-    }
-
-    /**
-     * Checks if the animatronic skips easing between poses.
-     */
-    @LuaFunction
-    public final boolean getShouldAnimate() {
-        return shouldAnimate;
+    public final void setAnimationMode(String mode) throws LuaException {
+        if (mode.equals("raw") || mode.equals("rusty")) {
+            AnimatronicBlockEntity be = super.getTarget();
+            if (be != null)
+                be.setAnimationMode(mode);
+        } else throw new LuaException("Given string must be either 'raw' or 'rusty'");
     }
 
     /**
@@ -77,7 +75,6 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     public final void push() {
         AnimatronicBlockEntity be = super.getTarget();
         if (be != null) {
-            be.setShouldAnimate(shouldAnimate);
             be.setHeadPose(headRot[0], headRot[1], headRot[2]);
             be.setBodyPose(bodyRot[0], bodyRot[1], bodyRot[2]);
             be.setLeftArmPose(leftArmRot[0], leftArmRot[1], leftArmRot[2]);

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/computercraft/peripherals/AnimatronicPeripheral.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/computercraft/peripherals/AnimatronicPeripheral.java
@@ -23,6 +23,7 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     private float[] bodyRot;
     private float[] leftArmRot;
     private float[] rightArmRot;
+    private boolean shouldAnimate;
 
     public AnimatronicPeripheral(AnimatronicBlockEntity blockEntity) {
         super("animatronic",blockEntity);
@@ -31,6 +32,7 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
         bodyRot = new float[]{0,0,0};
         leftArmRot = new float[]{0,0,0};
         rightArmRot = new float[]{0,0,0};
+        shouldAnimate = true;
     }
 
     /**
@@ -52,6 +54,22 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     }
 
     /**
+     * Sets if there should be easing between poses.
+     */
+    @LuaFunction
+    public final void setShouldAnimate(boolean shouldAnimate) {
+        this.shouldAnimate = shouldAnimate;
+    }
+
+    /**
+     * Checks if the animatronic skips easing between poses.
+     */
+    @LuaFunction
+    public final boolean getShouldAnimate() {
+        return shouldAnimate;
+    }
+
+    /**
      * Pushes the stored rotation values to the Animatronic.
      * After pushing them, the rotations get reset to 0 everywhere.
      */
@@ -59,6 +77,7 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     public final void push() {
         AnimatronicBlockEntity be = super.getTarget();
         if (be != null) {
+            be.setShouldAnimate(shouldAnimate);
             be.setHeadPose(headRot[0], headRot[1], headRot[2]);
             be.setBodyPose(bodyRot[0], bodyRot[1], bodyRot[2]);
             be.setLeftArmPose(leftArmRot[0], leftArmRot[1], leftArmRot[2]);

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/AnimatronicBlockEntity.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/AnimatronicBlockEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Rotations;
+import net.minecraft.nbt.ByteTag;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.network.protocol.Packet;
@@ -39,6 +40,7 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
     private Rotations start_leftArmPose = new Rotations(0,0,0);
     private Rotations start_rightArmPose = new Rotations(0,0,0);
 
+    private boolean shouldAnimate;
     private boolean isMoving;
     private double step;
     private long start_animation;
@@ -50,6 +52,7 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
     public AnimatronicBlockEntity(BlockPos pos, BlockState blockState) {
         super((BlockEntityType<AnimatronicBlockEntity>) CCCRegistries.ANIMATRONIC_BLOCK_ENTITY.get(), pos, blockState);
 
+        shouldAnimate = true;
         isMoving = true;
         step = 0.0;
         face = "normal";
@@ -65,7 +68,7 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
         current_leftArmPose = updatePose(start_leftArmPose, getDestinationLeftArmPose(), false);
         current_rightArmPose = updatePose(start_rightArmPose, getDestinationRightArmPose(), false);
 
-        if (step >= 1) {
+        if (step >= 1 || !shouldAnimate) {
             isMoving = false;
             current_headPose = getDestinationHeadPose();
             current_bodyPose = getDestinationBodyPose();
@@ -103,6 +106,8 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
         Rotations rightArmRot = ltRightArmPose.isEmpty() ? new Rotations(0,0,0) : new Rotations(ltRightArmPose);
         this.setRightArmPose(rightArmRot.getX(), rightArmRot.getY(), rightArmRot.getZ());
 
+        this.shouldAnimate = nbt.getBoolean("shouldAnimate");
+
         setFace(nbt.getString("face"));
 
         super.load(nbt);
@@ -113,6 +118,7 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
 
     @Override
     public void saveAdditional(@NotNull CompoundTag nbt) {
+        nbt.put("shouldAnimate", ByteTag.valueOf(shouldAnimate));
         nbt.put("headPose", getDestinationHeadPose().save());
         nbt.put("bodyPose", getDestinationBodyPose().save());
         nbt.put("leftArmPose", getDestinationLeftArmPose().save());
@@ -240,4 +246,6 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
     public Rotations getDestinationRightArmPose() {
         return rightArmPose;
     }
+
+    public void setShouldAnimate(boolean shouldAnimate) { this.shouldAnimate = shouldAnimate; }
 }

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/common/computercraft/peripherals/AnimatronicPeripheral.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/common/computercraft/peripherals/AnimatronicPeripheral.java
@@ -23,7 +23,6 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     private float[] bodyRot;
     private float[] leftArmRot;
     private float[] rightArmRot;
-    private boolean shouldAnimate;
 
     public AnimatronicPeripheral(AnimatronicBlockEntity blockEntity) {
         super("animatronic",blockEntity);
@@ -32,7 +31,6 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
         bodyRot = new float[]{0,0,0};
         leftArmRot = new float[]{0,0,0};
         rightArmRot = new float[]{0,0,0};
-        shouldAnimate = true;
     }
 
     /**
@@ -54,19 +52,19 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     }
 
     /**
-     * Sets if there should be easing between poses.
+     * Sets the Animatronic animation mode.
+     *
+     * @param mode The new mode. Must be either 'raw' or 'rusty'.
+     *
+     * @throws LuaException Whenever the given string is not one of those types.
      */
     @LuaFunction
-    public final void setShouldAnimate(boolean shouldAnimate) {
-        this.shouldAnimate = shouldAnimate;
-    }
-
-    /**
-     * Checks if the animatronic skips easing between poses.
-     */
-    @LuaFunction
-    public final boolean getShouldAnimate() {
-        return shouldAnimate;
+    public final void setAnimationMode(String mode) throws LuaException {
+        if (mode.equals("raw") || mode.equals("rusty")) {
+            AnimatronicBlockEntity be = super.getTarget();
+            if (be != null)
+                be.setAnimationMode(mode);
+        } else throw new LuaException("Given string must be either 'raw' or 'rusty'");
     }
 
     /**
@@ -77,7 +75,6 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     public final void push() {
         AnimatronicBlockEntity be = super.getTarget();
         if (be != null) {
-            be.setShouldAnimate(shouldAnimate);
             be.setHeadPose(headRot[0], headRot[1], headRot[2]);
             be.setBodyPose(bodyRot[0], bodyRot[1], bodyRot[2]);
             be.setLeftArmPose(leftArmRot[0], leftArmRot[1], leftArmRot[2]);

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/common/computercraft/peripherals/AnimatronicPeripheral.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/common/computercraft/peripherals/AnimatronicPeripheral.java
@@ -23,6 +23,7 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     private float[] bodyRot;
     private float[] leftArmRot;
     private float[] rightArmRot;
+    private boolean shouldAnimate;
 
     public AnimatronicPeripheral(AnimatronicBlockEntity blockEntity) {
         super("animatronic",blockEntity);
@@ -31,6 +32,7 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
         bodyRot = new float[]{0,0,0};
         leftArmRot = new float[]{0,0,0};
         rightArmRot = new float[]{0,0,0};
+        shouldAnimate = true;
     }
 
     /**
@@ -52,6 +54,22 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     }
 
     /**
+     * Sets if there should be easing between poses.
+     */
+    @LuaFunction
+    public final void setShouldAnimate(boolean shouldAnimate) {
+        this.shouldAnimate = shouldAnimate;
+    }
+
+    /**
+     * Checks if the animatronic skips easing between poses.
+     */
+    @LuaFunction
+    public final boolean getShouldAnimate() {
+        return shouldAnimate;
+    }
+
+    /**
      * Pushes the stored rotation values to the Animatronic.
      * After pushing them, the rotations get reset to 0 everywhere.
      */
@@ -59,6 +77,7 @@ public class AnimatronicPeripheral extends TweakedPeripheral<AnimatronicBlockEnt
     public final void push() {
         AnimatronicBlockEntity be = super.getTarget();
         if (be != null) {
+            be.setShouldAnimate(shouldAnimate);
             be.setHeadPose(headRot[0], headRot[1], headRot[2]);
             be.setBodyPose(bodyRot[0], bodyRot[1], bodyRot[2]);
             be.setLeftArmPose(leftArmRot[0], leftArmRot[1], leftArmRot[2]);

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/AnimatronicBlockEntity.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/AnimatronicBlockEntity.java
@@ -8,6 +8,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Rotations;
+import net.minecraft.nbt.ByteTag;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.network.protocol.Packet;
@@ -39,6 +40,7 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
     private Rotations start_leftArmPose = new Rotations(0,0,0);
     private Rotations start_rightArmPose = new Rotations(0,0,0);
 
+    private boolean shouldAnimate;
     private boolean isMoving;
     private double step;
     private long start_animation;
@@ -50,6 +52,7 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
     public AnimatronicBlockEntity(BlockPos pos, BlockState blockState) {
         super((BlockEntityType<AnimatronicBlockEntity>) CCCRegistries.ANIMATRONIC_BLOCK_ENTITY.get(), pos, blockState);
 
+        shouldAnimate = true;
         isMoving = true;
         step = 0.0;
         face = "normal";
@@ -65,7 +68,7 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
         current_leftArmPose = updatePose(start_leftArmPose, getDestinationLeftArmPose(), false);
         current_rightArmPose = updatePose(start_rightArmPose, getDestinationRightArmPose(), false);
 
-        if (step >= 1) {
+        if (step >= 1 || !shouldAnimate) {
             isMoving = false;
             current_headPose = getDestinationHeadPose();
             current_bodyPose = getDestinationBodyPose();
@@ -103,6 +106,8 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
         Rotations rightArmRot = ltRightArmPose.isEmpty() ? new Rotations(0,0,0) : new Rotations(ltRightArmPose);
         this.setRightArmPose(rightArmRot.getX(), rightArmRot.getY(), rightArmRot.getZ());
 
+        this.shouldAnimate = nbt.getBoolean("shouldAnimate");
+
         setFace(nbt.getString("face"));
 
         super.load(nbt);
@@ -113,6 +118,7 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
 
     @Override
     public void saveAdditional(@NotNull CompoundTag nbt) {
+        nbt.put("shouldAnimate", ByteTag.valueOf(shouldAnimate));
         nbt.put("headPose", getDestinationHeadPose().save());
         nbt.put("bodyPose", getDestinationBodyPose().save());
         nbt.put("leftArmPose", getDestinationLeftArmPose().save());
@@ -240,4 +246,6 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
     public Rotations getDestinationRightArmPose() {
         return rightArmPose;
     }
+
+    public void setShouldAnimate(boolean shouldAnimate) { this.shouldAnimate = shouldAnimate; }
 }

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/AnimatronicBlockEntity.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/AnimatronicBlockEntity.java
@@ -8,7 +8,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Rotations;
-import net.minecraft.nbt.ByteTag;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.network.protocol.Packet;
@@ -40,7 +39,7 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
     private Rotations start_leftArmPose = new Rotations(0,0,0);
     private Rotations start_rightArmPose = new Rotations(0,0,0);
 
-    private boolean shouldAnimate;
+    private String animationMode;
     private boolean isMoving;
     private double step;
     private long start_animation;
@@ -52,7 +51,7 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
     public AnimatronicBlockEntity(BlockPos pos, BlockState blockState) {
         super((BlockEntityType<AnimatronicBlockEntity>) CCCRegistries.ANIMATRONIC_BLOCK_ENTITY.get(), pos, blockState);
 
-        shouldAnimate = true;
+        animationMode = "rusty";
         isMoving = true;
         step = 0.0;
         face = "normal";
@@ -61,19 +60,33 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
 
     @OnlyIn(Dist.CLIENT)
     public void updateCurrentPoses(float partialTicks) {
-        step = (getLevel().getGameTime() - start_animation + partialTicks) * (0.0175 * 6);
+        switch (animationMode) {
+            case "rusty" -> {
+                step = (getLevel().getGameTime() - start_animation + partialTicks) * (0.0175 * 6);
 
-        current_headPose = updatePose(start_headPose, getDestinationHeadPose(), false);
-        current_bodyPose = updatePose(start_bodyPose, getDestinationBodyPose(), true);
-        current_leftArmPose = updatePose(start_leftArmPose, getDestinationLeftArmPose(), false);
-        current_rightArmPose = updatePose(start_rightArmPose, getDestinationRightArmPose(), false);
+                current_headPose = updatePose(start_headPose, getDestinationHeadPose(), false);
+                current_bodyPose = updatePose(start_bodyPose, getDestinationBodyPose(), true);
+                current_leftArmPose = updatePose(start_leftArmPose, getDestinationLeftArmPose(), false);
+                current_rightArmPose = updatePose(start_rightArmPose, getDestinationRightArmPose(), false);
 
-        if (step >= 1 || !shouldAnimate) {
-            isMoving = false;
-            current_headPose = getDestinationHeadPose();
-            current_bodyPose = getDestinationBodyPose();
-            current_leftArmPose = getDestinationLeftArmPose();
-            current_rightArmPose = getDestinationRightArmPose();
+                if (step >= 1) {
+                    isMoving = false;
+                    current_headPose = getDestinationHeadPose();
+                    current_bodyPose = getDestinationBodyPose();
+                    current_leftArmPose = getDestinationLeftArmPose();
+                    current_rightArmPose = getDestinationRightArmPose();
+                }
+            }
+            case "raw" -> {
+                // Could have used the old switch case syntax and done a fall through, but it's better to be explicit.
+                current_headPose = getDestinationHeadPose();
+                current_bodyPose = getDestinationBodyPose();
+                current_leftArmPose = getDestinationLeftArmPose();
+                current_rightArmPose = getDestinationRightArmPose();
+            }
+            default -> {
+                setAnimationMode("rusty"); // For old Animatronics
+            }
         }
     }
 
@@ -106,9 +119,9 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
         Rotations rightArmRot = ltRightArmPose.isEmpty() ? new Rotations(0,0,0) : new Rotations(ltRightArmPose);
         this.setRightArmPose(rightArmRot.getX(), rightArmRot.getY(), rightArmRot.getZ());
 
-        this.shouldAnimate = nbt.getBoolean("shouldAnimate");
-
         setFace(nbt.getString("face"));
+
+        setAnimationMode(nbt.getString("animationMode"));
 
         super.load(nbt);
 
@@ -118,13 +131,14 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
 
     @Override
     public void saveAdditional(@NotNull CompoundTag nbt) {
-        nbt.put("shouldAnimate", ByteTag.valueOf(shouldAnimate));
         nbt.put("headPose", getDestinationHeadPose().save());
         nbt.put("bodyPose", getDestinationBodyPose().save());
         nbt.put("leftArmPose", getDestinationLeftArmPose().save());
         nbt.put("rightArmPose", getDestinationRightArmPose().save());
         if (face != null)
             nbt.putString("face", face);
+        if (animationMode != null)
+            nbt.putString("animationMode", animationMode);
 
         super.saveAdditional(nbt);
     }
@@ -195,6 +209,10 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
         this.face = face;
     }
 
+    public void setAnimationMode(String animationMode) {
+        this.animationMode = animationMode;
+    }
+
     public void setRightArmPose(float x, float y, float z) {
         this.rightArmPose = new Rotations(x, y, z);
     }
@@ -246,6 +264,4 @@ public class AnimatronicBlockEntity extends BlockEntity implements PeripheralBlo
     public Rotations getDestinationRightArmPose() {
         return rightArmPose;
     }
-
-    public void setShouldAnimate(boolean shouldAnimate) { this.shouldAnimate = shouldAnimate; }
 }


### PR DESCRIPTION
---
Name: Feature Merge
Title: Animation Modes
About: Be able to change the way the Animatronic animates/tweens between poses.
Labels: Enhancement
Assignees: Rikaisan

---

### Description

I wanted to make an animatronic that had a really snappy and quick animation (think about a glitching/faulty robot), but that was not possible with the current implementation, so I added a new API to support what I needed + future expansion possibilities to the Animatronic:

`animatronic.setAnimationType(mode)` where `mode` can be either `rusty` or `raw` for now

The idea behind this implementation is to be able to add and support new tweening functions in the future with ease, think about the classic quadraticIn, exponentialOut, easeInOut, bounceIn and any other functions you might encounter in animation software.

Currently, I left the animation mode that was already implemented: 'rusty' as the default and added a new one: 'raw' which will skip the animation and just change the pose instantly to the one provided by the user when calling `animatronic.push()`.

For now, the implementation is using a switch statement to not over-complicate the code, however, if many more modes are expected to be added in the future, it might be worth it to create an interface for animation modes.