### PR TITLE
Fix RedRouter not firing redstone event

### DIFF
--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/RedRouterBlockEntity.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/RedRouterBlockEntity.java
@@ -64,6 +64,7 @@ public class RedRouterBlockEntity extends BlockEntity implements PeripheralBlock
 
             redrouter.blockupdate = false;
         }
+
         updateInputs(world, blockPos, redrouter);
 
         if (redrouter.newInputs && redrouter.peripheral != null) {
@@ -72,7 +73,7 @@ public class RedRouterBlockEntity extends BlockEntity implements PeripheralBlock
         }
     }
 
-    public static void updateInputs(Level world, BlockPos blockPos, RedRouterBlockEntity redrouter) {
+    public static void updateInputs(Level world, BlockPos blockPos, @NotNull RedRouterBlockEntity redrouter) {
         for (Map.Entry<String, Integer> entry : redrouter.inputDir.entrySet()) {
             String side = entry.getKey();
             Direction dir = Direction.byName(side).getOpposite();
@@ -80,6 +81,9 @@ public class RedRouterBlockEntity extends BlockEntity implements PeripheralBlock
             BlockState block = world.getBlockState(offsetPos);
 
             int power = block.getBlock().getSignal(block, world, offsetPos, dir);
+
+            if (redrouter.inputDir.get(side) != power) { redrouter.newInputs = true; }
+
             redrouter.inputDir.put(side, power);
         }
     }

--- a/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/RedRouterBlockEntity.java
+++ b/fabric/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/RedRouterBlockEntity.java
@@ -64,7 +64,6 @@ public class RedRouterBlockEntity extends BlockEntity implements PeripheralBlock
 
             redrouter.blockupdate = false;
         }
-
         updateInputs(world, blockPos, redrouter);
 
         if (redrouter.newInputs && redrouter.peripheral != null) {
@@ -73,7 +72,7 @@ public class RedRouterBlockEntity extends BlockEntity implements PeripheralBlock
         }
     }
 
-    public static void updateInputs(Level world, BlockPos blockPos, @NotNull RedRouterBlockEntity redrouter) {
+    public static void updateInputs(Level world, BlockPos blockPos, RedRouterBlockEntity redrouter) {
         for (Map.Entry<String, Integer> entry : redrouter.inputDir.entrySet()) {
             String side = entry.getKey();
             Direction dir = Direction.byName(side).getOpposite();

--- a/forge/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/RedRouterBlockEntity.java
+++ b/forge/src/main/java/cc/tweaked_programs/cccbridge/common/minecraft/blockEntity/RedRouterBlockEntity.java
@@ -80,6 +80,9 @@ public class RedRouterBlockEntity extends BlockEntity implements PeripheralBlock
             BlockState block = world.getBlockState(offsetPos);
 
             int power = block.getBlock().getSignal(block, world, offsetPos, dir);
+
+            if (redrouter.inputDir.get(side) != power) { redrouter.newInputs = true; }
+
             redrouter.inputDir.put(side, power);
         }
     }


### PR DESCRIPTION
Noticed the red router wasn't sending the event and it was just the `newinputs` variable not being set to true anywhere, so I added the check that it was missing.

I also noticed that the redrouter only fires the event when strong powered, but since this seems to be intentional, I left it as is; Let me know if this behavior is not meant to be intentional and I'll modify it so that it also accepts soft powering.

Fixes #94 